### PR TITLE
Factory Method Pattern

### DIFF
--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16.java
@@ -1,0 +1,23 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16 {
+    IEngine engine;
+    ICockpit cockpit;
+
+    protected F16 makeF16() {
+        engine = new F16Engine();
+        cockpit = new F16Cockpit();
+        return this;
+    }
+
+    public void taxi() {
+        System.out.println("--F16 is taxing on the runway!--");
+    }
+
+    public void fly() {
+        //superclass doesn't know what type of F16 is flying
+        F16 f16 = makeF16();
+        f16.taxi();
+        System.out.println("F16 is airborne.");
+    }
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16A.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16A.java
@@ -1,0 +1,10 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16A extends F16 {
+    @Override
+    protected F16 makeF16() {
+        super.makeF16();
+        engine = new F16AEngine();
+        return this;
+    }
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16AEngine.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16AEngine.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16AEngine implements IEngine{
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16B.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16B.java
@@ -1,0 +1,10 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16B extends F16{
+    @Override
+    protected F16 makeF16() {
+        super.makeF16();
+        engine = new F16BEngine();
+        return this;
+    }
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16BEngine.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16BEngine.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16BEngine implements IEngine{
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16Cockpit.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16Cockpit.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16Cockpit implements ICockpit {
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16Engine.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16Engine.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public class F16Engine implements IEngine{
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/F16SimpleFactory.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/F16SimpleFactory.java
@@ -1,0 +1,15 @@
+package com.designpatterns.app.creational.factorymethod;
+
+//Not the same as factory method pattern
+public class F16SimpleFactory {
+    public F16 makeF16(String variant) {
+        switch(variant) {
+            case "A":
+                return new F16A();
+            case "B":
+                return new F16B();
+            default:
+                return new F16();
+        }
+    }
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/ICockpit.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/ICockpit.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public interface ICockpit {
+}

--- a/src/main/java/com/designpatterns/app/creational/factorymethod/IEngine.java
+++ b/src/main/java/com/designpatterns/app/creational/factorymethod/IEngine.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.creational.factorymethod;
+
+public interface IEngine {
+}

--- a/src/test/java/com/designpatterns/app/creational/factorymethod/F16FactoryTest.java
+++ b/src/test/java/com/designpatterns/app/creational/factorymethod/F16FactoryTest.java
@@ -1,0 +1,27 @@
+package com.designpatterns.app.creational.factorymethod;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class F16FactoryTest {
+    @Test
+    public void testFactoryF16Creation() {
+        F16SimpleFactory f16SimpleFactory = new F16SimpleFactory();
+        F16 f16A = f16SimpleFactory.makeF16("A");
+        F16 f16B = f16SimpleFactory.makeF16("B");
+
+        f16A.fly();
+        f16B.fly();
+        assertNotEquals(f16A, f16B);
+    }
+
+    @Test
+    public void testFactoryMethodPatternF16() {
+        F16 f16A = new F16A();
+        F16 f16B = new F16B();
+        F16 secondF16B = f16B.makeF16();
+        assertNotEquals(f16A, f16B);
+        assertNotEquals(f16A.engine, secondF16B.engine);
+    }
+}


### PR DESCRIPTION
# Summary
Simple Factory and Factory Method Pattern are demoed. The Factory Method pattern allows you to subclass the root object and delegate the particular variations to a specific method. In this case makeF16 calls the super class, but changes the engine type for each type of an F16.