### PR TITLE
Memento Pattern

### DIFF
--- a/src/main/java/com/designpatterns/app/behavioral/memento/BlackBox.java
+++ b/src/main/java/com/designpatterns/app/behavioral/memento/BlackBox.java
@@ -1,0 +1,56 @@
+package com.designpatterns.app.behavioral.memento;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.*;
+
+@Slf4j
+public class BlackBox implements Serializable {
+    private long altitude;
+    private double speed;
+    private float engineTemperature;
+    private static final long serialVersionUID = 1L;
+
+    public BlackBox(long altitude, double speed, float engineTemperature) {
+        this.altitude = altitude;
+        this.speed = speed;
+        this.engineTemperature = engineTemperature;
+    }
+
+    public double getSpeed() {
+        return this.speed;
+    }
+
+    public void setSpeed(double newSpeed) {
+        this.speed = newSpeed;
+    }
+
+    //saving state as a byte stream
+    public byte[] getState() throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutput out = null;
+        byte[] memento = null;
+        try {
+            out = new ObjectOutputStream(bos);
+            out.writeObject(this);
+            out.flush();
+            memento = bos.toByteArray();
+        } finally {
+            try {
+                bos.close();
+            } catch (IOException ex) {
+                log.error("Something's wrong with streaming this object {}", ex.getCause());
+            }
+        }
+        return memento;
+    }
+
+    //restoring state
+    public BlackBox setState(byte[] memento) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(memento);
+        ObjectInputStream ois = new ObjectInputStream(inputStream);
+        BlackBox blackBox = (BlackBox) ois.readObject();
+        ois.close();
+        return blackBox;
+    }
+}

--- a/src/main/java/com/designpatterns/app/behavioral/memento/Something.java
+++ b/src/main/java/com/designpatterns/app/behavioral/memento/Something.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.behavioral.memento;
+
+public class Something {
+}

--- a/src/main/java/com/designpatterns/app/behavioral/memento/Something.java
+++ b/src/main/java/com/designpatterns/app/behavioral/memento/Something.java
@@ -1,4 +1,0 @@
-package com.designpatterns.app.behavioral.memento;
-
-public class Something {
-}

--- a/src/test/java/com/designpatterns/app/behavioral/memento/MementoPatternTest.java
+++ b/src/test/java/com/designpatterns/app/behavioral/memento/MementoPatternTest.java
@@ -1,0 +1,4 @@
+package com.designpatterns.app.behavioral.memento;
+
+public class MementoPatternTest {
+}

--- a/src/test/java/com/designpatterns/app/behavioral/memento/MementoPatternTest.java
+++ b/src/test/java/com/designpatterns/app/behavioral/memento/MementoPatternTest.java
@@ -1,4 +1,21 @@
 package com.designpatterns.app.behavioral.memento;
 
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class MementoPatternTest {
+    @Test
+    public void testMementoBehavior() throws IOException, ClassNotFoundException {
+        BlackBox blackBox = new BlackBox(12350L, 88.2, 225.08f);
+        byte[] memento = blackBox.getState();
+        assertEquals(88.2, blackBox.getSpeed());
+        blackBox.setSpeed(0);
+        assertEquals(0, blackBox.getSpeed());
+        //restore state
+        blackBox = blackBox.setState(memento);
+        assertEquals(88.2, blackBox.getSpeed());
+    }
 }


### PR DESCRIPTION
# Summary
Memento pattern lets us capture the internal state of an object without exposing its internal structure so that the object can be restored to this state later.
![image](https://user-images.githubusercontent.com/3682978/142796226-4928c38f-f821-4704-812e-00a64776fcc8.png)

